### PR TITLE
mlnx-bf.conf: Added 2 new flags

### DIFF
--- a/src/mlnx-bf.conf
+++ b/src/mlnx-bf.conf
@@ -1,1 +1,7 @@
 ALLOW_SHARED_RQ="yes"
+SW_STEERING="yes"
+
+# Please note, IPsec full offload requires FW steering,
+# Please make sure SW_STEERING="no" in case of IPSEC_FULL_OFFLOAD="yes"
+
+IPSEC_FULL_OFFLOAD="no"


### PR DESCRIPTION
Added SW_STEERING for specifying if to work with SW steering.
Added IPSEC_FULL_OFFLOAD for specifying if to work with IPsec full
offload mode.

Signed-off-by: Emeel Hakim <ehakim@nvidia.com>