### PR TITLE
mlnx-bf.conf: Added IPSEC_FULL_OFFLOAD flag

### DIFF
--- a/src/mlnx-bf.conf
+++ b/src/mlnx-bf.conf
@@ -1,1 +1,6 @@
 ALLOW_SHARED_RQ="yes"
+
+# Please note, IPsec full offload requires FW steering,
+# Please note that setting IPSEC_FULL_OFFLOAD="yes" with automatically move to FW steering.
+
+IPSEC_FULL_OFFLOAD="no"


### PR DESCRIPTION
Added IPSEC_FULL_OFFLOAD for specifying if to work with IPsec full
offload mode.

Signed-off-by: Emeel Hakim <ehakim@nvidia.com>