### PR TITLE
DOCA Telemetry: Updated import script to copy yaml file

### DIFF
--- a/src/import_doca_telemetry.sh
+++ b/src/import_doca_telemetry.sh
@@ -3,6 +3,7 @@
 cd ${0%*/*}
 
 doca_telemetry=`/bin/ls doca_telemetry_service*arm64.tar`
+doca_telemetry_yaml=`/bin/ls doca_telemetry*.yaml`
 
 if [ ! -n $doca_telemetry ]; then
 	echo "DOCA telemetry container image was not found"
@@ -27,3 +28,4 @@ ex systemctl start kubelet.service
 ex systemctl start containerd.service
 
 ex ctr --namespace k8s.io image import $doca_telemetry
+ex cp $doca_telemetry_yaml /etc/kubelet.d/


### PR DESCRIPTION
Added copy for doca telemetry yaml to /etc/kubelet.d/ in order to run the container after boot

Signed-off-by: Orsan Awwad <oawwad@nvidia.com>