### PR TITLE
Support acpi event files for the GPIO reboot interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,8 @@ src/debian-network/enp3s0f0s0
 
 src/debian-network/enp3s0f1s0
 
+# ACPI power button configurations
+
+src/mlnx-powerconf
+
+src/rebootcontrol

--- a/bf-release.spec
+++ b/bf-release.spec
@@ -11,6 +11,7 @@ Source: %{name}-%{version}.tar.gz
 BuildRequires: redhat-lsb-core
 %endif
 Requires: kexec-tools
+Requires: acpid
 BuildRoot: %{?build_root:%{build_root}}%{!?build_root:/var/tmp/%{name}-%{version}-root}
 Vendor: Nvidia
 %description
@@ -128,6 +129,12 @@ install -m 0644 src/45-mlnx-dns.conf	%{buildroot}/etc/NetworkManager/conf.d/
 install -d %{buildroot}/etc/mellanox
 install -m 0644 src/mlnx-bf.conf	%{buildroot}/etc/mellanox
 install -m 0644 src/mlnx-ovs.conf	%{buildroot}/etc/mellanox
+
+install -d %{buildroot}/etc/acpi/actions/
+install -m 0755 src/rebootcontrol	%{buildroot}/etc/acpi/actions/
+
+install -d %{buildroot}/etc/acpi/events/
+install -m 0644 src/mlnx-powerconf	%{buildroot}/etc/acpi/events/
 
 # mlnx-snap
 install -d %{buildroot}/opt/mellanox/mlnx_snap/exec_files
@@ -283,6 +290,12 @@ fi
 %files
 /etc/mlnx-release
 %{_datadir}/%{name}/config.toml
+
+%dir /etc/acpi/events/
+/etc/acpi/events/mlnx-powerconf
+
+%dir /etc/acpi/actions/
+/etc/acpi/actions/rebootcontrol
 
 %dir /opt/mellanox/hlk
 /opt/mellanox/hlk/*

--- a/debian/control
+++ b/debian/control
@@ -9,4 +9,5 @@ Maintainer: Vladimir Sokolovsky <vlad@nvidia.com>
 Package: bf-release
 Architecture: arm64
 Depends: kexec-tools
+Depends: acpid
 Description: BF release information

--- a/debian/rules
+++ b/debian/rules
@@ -90,6 +90,11 @@ endif
 	install -m 0644 src/mlnx-bf.conf	debian/$(pname)/etc/mellanox
 	install -m 0644 src/mlnx-ovs.conf	debian/$(pname)/etc/mellanox
 
+	dh_installdirs -p$(pname)  etc/acpi/actions
+	install -m 0755 src/rebootcontrol	debian/$(pname)/etc/acpi/actions
+	dh_installdirs -p$(pname)  etc/acpi/events
+	install -m 0644 src/mlnx-powerconf	debian/$(pname)/etc/acpi/events
+
 	# Cloud-init
 	dh_installdirs -p$(pname)  var/lib/cloud
 	cp -a src/cloud/* debian/$(pname)/var/lib/cloud

--- a/src/mlnx-powerconf
+++ b/src/mlnx-powerconf
@@ -1,0 +1,3 @@
+event=button/reboot.*
+action=/etc/acpi/actions/rebootcontrol
+

--- a/src/rebootcontrol
+++ b/src/rebootcontrol
@@ -1,0 +1,3 @@
+#!/bin/bash
+reboot
+


### PR DESCRIPTION
For both BF2 and BF3, there is a GPIO controlled by the BMC, responsible to trigger the DPU graceful reboot.

Until now the requirement was a soft reset (forced reboot) but this requirement has been changed following the request from a customer. So for all distros and both BF2/BF3, change the behavior to graceful reboot. To achieve that, create acpi event files:
/etc/acpi/events/mlnx-powerconf and
/etc/acpi/actions/rebootcontrol.

This change works hand in hand with the pwr-mlxbf driver.

RM #3591305