### PR TITLE
Disable strongswan-starter.service

### DIFF
--- a/bf-release.spec
+++ b/bf-release.spec
@@ -276,6 +276,7 @@ enable_service kdump.service
 disable_service openvswitch-ipsec
 disable_service ibacm.service
 disable_service opensmd.service
+disable_service strongswan-starter.service
 
 fi
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -139,5 +139,6 @@ disable_service ibacm.service
 disable_service opensmd.service
 disable_service unattended-upgrades.service
 disable_service apt-daily-upgrade.timer
+disable_service strongswan-starter.service
 
 #DEBHELPER#


### PR DESCRIPTION
Disable strongswan-starter.service as it's a legacy unit (see (1)) and may conflict with the modern unit strongswan.service.

(1) https://wiki.strongswan.org/projects/strongswan/wiki/580