### PR TITLE
Update-condition-Support-RHEL9

### DIFF
--- a/bf-release.spec
+++ b/bf-release.spec
@@ -7,8 +7,8 @@ License: GPLv2/BSD
 Url: https://developer.nvidia.com/networking/doca
 Group: System Environment/Base
 Source: %{name}-%{version}.tar.gz
-%if "%_vendor" == "redhat"
-BuildRequires: lsb_release
+%if "%_vendor" == "redhat" && 0%{?rhel} < 9
+BuildRequires: redhat-lsb-core
 %endif
 Requires: kexec-tools
 Requires: acpid

--- a/bf-release.spec
+++ b/bf-release.spec
@@ -8,7 +8,7 @@ Url: https://developer.nvidia.com/networking/doca
 Group: System Environment/Base
 Source: %{name}-%{version}.tar.gz
 %if "%_vendor" == "redhat"
-BuildRequires: redhat-lsb-core
+BuildRequires: lsb_release
 %endif
 Requires: kexec-tools
 Requires: acpid


### PR DESCRIPTION
Updated BuildRequier condition, in order to allow bf-release build for RHEL9