### PR TITLE
Apply override_dh_fixperms target to Ubuntu only

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -134,4 +134,6 @@ endif
 
 override_dh_fixperms:
 	dh_fixperms
+ifeq ($(DIST_NAME_L), ubuntu)
 	chmod 600 debian/$(pname)/etc/netplan/60-mlnx.yaml
+endif


### PR DESCRIPTION
This change ensures the `override_dh_fixperms` target runs for Ubuntu only.

Fixes #41