### PR TITLE
Add BMC/CEC and other changes to bf-info of lts-Nov2024 

### DIFF
--- a/src/bf-info
+++ b/src/bf-info
@@ -63,7 +63,7 @@ get_version_and_release()
 print_ofed()
 {
 	if [ -e /etc/debian_version ]; then
-		ofed_info | sed -n '/^-------------------$/ { :a; n; p; ba; }' | awk '{print $2, $3}'
+		ofed_info | sed -n '/^-------------------$/ { :a; n; p; ba; }' | awk 'NF {print "- " $2, $3}'
 	else
 		ofed_info | sed -n '/^-------------------$/ { :a; n; p; ba; }' | xargs rpm -q --queryformat="[- %{NAME} %{VERSION}-%{RELEASE}]\n"
 	fi
@@ -88,33 +88,29 @@ get_cec_fw()
 }
 
 cat << EOF
+
 Firmware:
 - ATF: $BUILD_ATF
 - UEFI: $BUILD_UEFI
+- BSP: $BUILD_BSP
 - NIC Firmware: $NIC_FW
 - BMC Firmware: `get_bmc_fw`
 - CEC Firmware: `get_cec_fw`
 
-Versions:
-- DOCA Base (OFED): ${OFED}
-- BSP: $BUILD_BSP
-- mlnx-dpdk: `/opt/mellanox/dpdk/bin/dpdk-testpmd -v 2>&1 | grep "RTE Version:" | cut -d ':' -f 3`
+Drivers:
+- mlnx-dpdk:`/opt/mellanox/dpdk/bin/dpdk-testpmd -v 2>&1 | grep "RTE Version:" | cut -d ':' -f 3`
 - Kernel: $(uname -r)
+
+Tools:
 - MFT: `get_version_and_release mft`
 - mstflint: `get_version_and_release mstflint`
 EOF
 if [ -n "$MLX_REGEX" ]; then
     echo "- mlx-regex: ${MLX_REGEX}"
 fi
-cat << EOF
-- collectx-clxapi: `get_version collectx-clxapi`
-- libvma: `get_version libvma`
-EOF
 
 if ( grep -q "DISTRIB_ID=Ubuntu" /etc/lsb-release > /dev/null 2>&1 ); then
 cat << EOF
-- `get_version libxlio`
-- `get_version dpcp`
 EOF
 fi
 
@@ -143,12 +139,14 @@ cat << EOF
 
 DOCA:
 $(for doca in `dpkg --list | grep -E 'doca|rxp|dpa-compiler' | awk '{print $2}' | sort -n`; do echo "- `get_version $doca`";done)
+- collectx-clxapi: `get_version collectx-clxapi`
 EOF
 else
 cat << EOF
 
 DOCA:
 $(for doca in $(rpm -qa | grep -E 'doca|rxp|dpa-compiler' | sort -n); do echo "- `get_version $doca`";done)
+- collectx-clxapi: `get_version collectx-clxapi`
 EOF
 fi
 
@@ -188,6 +186,7 @@ cat << EOF
 
 OFED:
 `print_ofed`
+
 EOF
 fi
 

--- a/src/bf-info
+++ b/src/bf-info
@@ -47,6 +47,7 @@ elif [ "$DEV_TYPE" == "BlueField3" ]; then
     NIC_FW=`/opt/mellanox/mlnx-fw-updater/firmware/mlxfwmanager_sriov_dis_aarch64_41692 --list 2> /dev/null | head -3 | tail -1 | awk '{print $4}'`
 fi
 
+MLX_REGEX=$(get_version mlx-regex 2> /dev/null)
 
 get_version_and_release()
 {
@@ -68,19 +69,44 @@ print_ofed()
 	fi
 }
 
+get_bmc_fw()
+{
+	if [ -e /lib/firmware/mellanox/bmc/bf2-bmc-fw.version ]; then
+		cat /lib/firmware/mellanox/bmc/bf2-bmc-fw.version
+	elif [ -e /lib/firmware/mellanox/bmc/bf3-bmc-fw.version ]; then
+		cat /lib/firmware/mellanox/bmc/bf3-bmc-fw.version
+	fi
+}
+
+get_cec_fw()
+{
+	if [ -e /lib/firmware/mellanox/cec/bf2-cec-fw.version ]; then
+		cat /lib/firmware/mellanox/cec/bf2-cec-fw.version
+	elif [ -e /lib/firmware/mellanox/cec/bf3-cec-fw.version ]; then
+		cat /lib/firmware/mellanox/cec/bf3-cec-fw.version
+	fi
+}
 
 cat << EOF
-Versions:
+Firmware:
 - ATF: $BUILD_ATF
 - UEFI: $BUILD_UEFI
-- BSP: $BUILD_BSP
 - NIC Firmware: $NIC_FW
-- Kernel: $(uname -r)
+- BMC Firmware: `get_bmc_fw`
+- CEC Firmware: `get_cec_fw`
+
+Versions:
 - DOCA Base (OFED): ${OFED}
+- BSP: $BUILD_BSP
+- mlnx-dpdk: `/opt/mellanox/dpdk/bin/dpdk-testpmd -v 2>&1 | grep "RTE Version:" | cut -d ':' -f 3`
+- Kernel: $(uname -r)
 - MFT: `get_version_and_release mft`
 - mstflint: `get_version_and_release mstflint`
-- mlnx-dpdk: `/opt/mellanox/dpdk/bin/dpdk-testpmd -v 2>&1 | grep "RTE Version:" | cut -d ':' -f 3`
-- mlx-regex: `get_version mlx-regex`
+EOF
+if [ -n "$MLX_REGEX" ]; then
+    echo "- mlx-regex: ${MLX_REGEX}"
+fi
+cat << EOF
 - collectx-clxapi: `get_version collectx-clxapi`
 - libvma: `get_version libvma`
 EOF


### PR DESCRIPTION
A couple of bf-info commits from master branch 

[DPU Integration] Bug SW [#4547322](https://redmine.mellanox.com/issues/4547322): [DOCA 2.9.3-aug-fur] bf-info missing BMC, CEC Firmware versions | Assignee: Mor Tel Tsur | Status: Assigned
