### PR TITLE
Add wait_no_bmc_tasks for golden image updates

### DIFF
--- a/src/bf-upgrade.env/bmc
+++ b/src/bf-upgrade.env/bmc
@@ -357,6 +357,55 @@ wait_bmc_task_complete()
 	/bin/rm -f $output
 }
 
+wait_no_bmc_tasks()
+{
+	bmc_get_task_id
+	if [ -z "${task_id}" ]; then
+		ilog "No active BMC task"
+		return 0
+	fi
+	output=$(mktemp)
+	get_bmc_token
+	curl -sSk -H "X-Auth-Token: $BMC_TOKEN" https://${BMC_IP}${task_id} > $output
+	percent_done=$(cat $output | jq -r ' .PercentComplete')
+	SECONDS=0
+	while [ "$percent_done" != "100" ]; do
+		if [ "$percent_done" == "null" ]; then
+			ilog "- ERROR: There is no task with task id: $task_id"
+			RC=$((RC+1))
+			break
+		fi
+		if [ $SECONDS -gt $BMC_TASK_TIMEOUT ]; then
+			ilog "- ERROR: BMC task $task_id timeout"
+			RC=$((RC+1))
+			break
+		fi
+		get_bmc_token
+		curl -sSk -H "X-Auth-Token: $BMC_TOKEN" https://${BMC_IP}${task_id} > $output
+		percent_done=$(cat $output | jq -r ' .PercentComplete')
+		task_state=$(cat $output | jq -r ' .TaskState')
+		if [ "$task_state" == "Exception" ]; then
+			ilog "- ERROR: BMC task $task_id exception"
+			RC=$((RC+1))
+			break
+		elif [ "$task_state" == "Cancelled" ]; then
+			ilog "- ERROR: BMC task $task_id cancelled"
+			RC=$((RC+1))
+			break
+		fi
+		sleep 10
+	done
+	task_state=$(jq '.TaskState' $output | tr -d '"')
+	task_status=$(jq '.TaskStatus' $output | tr -d '"')
+
+	if [ "$task_state$task_status" != "CompletedOK" ]; then
+		echo "BMC task failed:"  >> $LOG
+		cat $output >> $LOG
+		RC=$((RC+1))
+	fi
+	/bin/rm -f $output
+}
+
 get_bmc_firmware_version()
 {
 	get_bmc_token
@@ -593,7 +642,7 @@ update_dpu_golden_image()
 		image_type="bfb"
 	fi
 
-	wait_bmc_task_complete
+	wait_no_bmc_tasks
 
 	if [ "$image_type" == "bfb" ]; then
 		prepare_sshpass_environment
@@ -640,7 +689,7 @@ update_dpu_golden_image()
 	if (echo "${BD_PSIDS}" | grep -qw "${PSID}"); then
 		if [ "X${UPLOAD_CONFIG_IMAGE}" == "Xyes" ]; then
 
-			wait_bmc_task_complete
+			wait_no_bmc_tasks
 
 			if [ "X${GENERATE_CONFIG_IMAGE}" == "Xyes" ]; then
 				generate_config_image $image
@@ -691,7 +740,7 @@ update_nic_firmware_golden_image()
 		image_type="bfb"
 	fi
 
-	wait_bmc_task_complete
+	wait_no_bmc_tasks
 
 	if [ "$image_type" == "bfb" ]; then
 		prepare_sshpass_environment


### PR DESCRIPTION
Initial state:
Golden image updates (DPU and NIC FW) called
wait_bmc_task_complete which also polls
BackgroundCopyStatus on Bluefield_ERoT, adding
unnecessary delay when only task completion
matters.

Suggested change:
Added wait_no_bmc_tasks() that only monitors
BMC TaskService tasks without checking background
copy status. Replaced wait_bmc_task_complete calls in update_dpu_golden_image and
update_nic_firmware_golden_image with the new
function.

Why:
Golden image operations only need to ensure no
other BMC tasks are running; the background copy
check is irrelevant and adds unneeded latency.
Background copy tasks are only relevant to check pre CEC/BMC update

Made-with: Cursor