### PR TITLE
bf-release.spec: detect RHCOS via VARIANT_ID

### DIFF
--- a/bf-release.spec
+++ b/bf-release.spec
@@ -190,11 +190,12 @@ install -d %{buildroot}/%{_datadir}/%{name}
 install -m 0755	src/bf-info           %{buildroot}/usr/bin/bf-info
 
 %post
-# RHEL 9.4 ships with Ignition / MachineConfigOperator owning these paths;
+# RHCOS owns these paths via Ignition / MachineConfigOperator;
 # remove them on every install/upgrade so we don't conflict.
+# RHCOS reports ID=rhel, so VARIANT_ID is the real discriminator.
 if [ -e /etc/os-release ]; then
     . /etc/os-release
-    if [ "${ID}" = "rhel" ] && [ "${VERSION_ID}" = "9.4" ]; then
+    if [ "${VARIANT_ID}" = "coreos" ]; then
         rm -f /etc/sysconfig/network-scripts/ifcfg-tmfifo_net0 \
               /etc/sysconfig/network-scripts/ifcfg-oob_net0 \
               /etc/NetworkManager/conf.d/40-mlnx.conf \


### PR DESCRIPTION
### Current state
The %post scriptlet guards ifcfg/NetworkManager file removal with ID=rhel && VERSION_ID=9.4, which is too narrow — it only fires on one specific RHEL point-release.

### Change
Replace the version-pinned check with VARIANT_ID=coreos, which is the canonical field that CoreOS-family systems (RHCOS, FCOS) always set regardless of VERSION_ID.

### Why
RHCOS reports ID=rhel in /etc/os-release, making the ID check insufficient. VARIANT_ID=coreos is the real discriminator and works across all future RHCOS/FCOS versions without needing updates.