### PR TITLE
bf-release: run depmod for all kernels on upgrade to fix dracut failure

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -22,6 +22,17 @@ disable_service()
 }
 
 if [ "$1" = "configure" ]; then
+
+	if [ -n "$2" ]; then
+		# Upgrade only: refresh module deps for every installed kernel so a
+		# stale modules.dep on the outgoing kernel (e.g. OFED RDMA modules
+		# replaced for a new kver) doesn't break the dracut trigger.
+		for kdir in /lib/modules/*/; do
+			kver=$(basename "$kdir")
+			[ -e "$kdir/modules.dep" ] || continue
+			depmod -a "$kver" || true
+		done
+	fi
 	if [ -z "$2" ]; then
 		# Fresh install, not an upgrade
 		if (grep -q OFED-internal /usr/bin/ofed_info > /dev/null 2>&1); then


### PR DESCRIPTION
DOCA upgrades that add a new kernel can leave the outgoing kernel's modules.dep out of date when OFED *-modules replace its .ko files, so the dracut trigger fails on missing updates/*rdma.ko. The postinst now reruns depmod for every installed kernel on upgrade. The underlying cause lives in the OFED *-modules scripts (depmod for the kver that needs update); this serves as a complementary bf-release-side safeguard.