### PR TITLE
Run depmod for all kernels on upgrade to fix dracut failure and Omit iscsi from Dracut modules

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -22,6 +22,22 @@ disable_service()
 }
 
 if [ "$1" = "configure" ]; then
+	if [ -n "$2" ]; then
+		# Upgrade only
+
+		# Omit iscsi from dracut modules to remove unrelevant error during upgrade
+		# Note: Leading and trailing spaces inside the quotes — dracut requires them for += list options.
+		echo 'omit_dracutmodules+=" iscsi "' | sudo tee /etc/dracut.conf.d/01-bf-omit-iscsi.conf
+
+		# Refresh module deps for every installed kernel so a
+		# stale modules.dep on the outgoing kernel (e.g. OFED RDMA modules
+		# replaced for a new kver) doesn't break the dracut trigger.
+		for kdir in /lib/modules/*/; do
+			kver=$(basename "$kdir")
+			[ -e "$kdir/modules.dep" ] || continue
+			depmod -a "$kver" || true
+		done
+	fi
 	if [ -z "$2" ]; then
 		# Fresh install, not an upgrade
 		if (grep -q OFED-internal /usr/bin/ofed_info > /dev/null 2>&1); then


### PR DESCRIPTION
DOCA upgrades that add a new kernel can leave the outgoing kernel's modules.dep out of date when OFED *-modules replace its .ko files, so the dracut trigger fails on missing updates/*rdma.ko.
The postinst now reruns depmod for every installed kernel on upgrade.
The underlying cause lives in the OFED *-modules scripts (depmod for the kver that needs update);
this serves as a complementary bf-release-side safeguard.

iscsi cause cosmetic failure during upgrade. Hence, omitting iscsi from dracut module.