### PR TITLE
OOB udev: Toggle link if detected down during boot

### DIFF
--- a/src/92-oob_net.rules
+++ b/src/92-oob_net.rules
@@ -1,3 +1,4 @@
 SUBSYSTEM=="net", ACTION=="add", DEVPATH=="/devices/platform/MLNXBF17:00/net/e*", NAME="oob_net0", RUN+="/sbin/sysctl -w net.ipv4.conf.oob_net0.arp_notify=1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="virtio_net", PROGRAM="/bin/sh -c 'lspci -vv | grep -wq SimX'", NAME="oob_net0", RUN+="/sbin/sysctl -w net.ipv4.conf.oob_net0.arp_notify=1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="lan743x", NAME="oob_net0", RUN+="/sbin/sysctl -w net.ipv4.conf.oob_net0.arp_notify=1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="lan743x", NAME="oob_net0", ATTR{operstate}=="down", RUN+="/bin/sh -c '/sbin/ip link set dev oob_net0 down; /sbin/ip link set dev oob_net0 up'"


### PR DESCRIPTION
This commit toggles OOB link status when detecting it down during booting, which is a workaround for link down issue (probably due to phy stuck). The workaround can be removed once the root cause is fixed.

NVBUG #6105761