### PR TITLE
Point DOCA repo to latest-2.9-LTS and update GPG key

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ src/mlnx-ovs.conf
 
 # DOCA APT repository
 
-src/doca.list
+src/doca.list - Static example of the DOCA APT repo configuration. The actual
+file installed on-device is generated dynamically by `debian/rules` using
+`lsb_release` to detect the OS and version at build time. Points to the
+`latest-2.9-LTS` repo path; uses `nvidia-doca-debian-gpg-public-key.asc`
+for key import.
 
 # Cloud-init conifugration files for Ubuntu
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 bf-release (4.9.5) UNRELEASED; urgency=medium
 
   * 4.9.5 release
+  * Point DOCA repo to latest-2.9-LTS, update GPG key to
+    nvidia-doca-debian-gpg-public-key.asc, rename arch aarch64 -> arm64-dpu
 
- -- Vladimir Sokolovsky <vlad@nvidia.com>  Thu, 12 Feb 2026 15:56:23 +0000
+ -- Moshe Sheena <msheena@nvidia.com>  Mon, 22 Jun 2026 15:47:00 +0000
 
 bf-release (4.9.4) UNRELEASED; urgency=medium
 

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ BF_KERNEL := $(shell dpkg -L mlnx-ofed-kernel-modules | grep -o [0-9].*bluefield
 BF_VERSION := $(shell dpkg-query --showformat='${Version}' --show mlxbf-bootimages 2> /dev/null | sed -e 's/-/./g')
 
 BFB_VERSION := $(shell cat /etc/mlnx-release 2> /dev/null)
-ARCH := aarch64
+ARCH := arm64-dpu
 
 %:
 	dh $@
@@ -46,8 +46,8 @@ override_dh_auto_install:
 	echo "# For more information, refer to http://linux.mellanox.com" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	echo "#" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	echo "# To add public key:" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
-	echo "# wget -qO - https://linux.mellanox.com/public/repo/doca/latest/$(DIST_NAME_L)$(DIST_VERSION)/aarch64/GPG-KEY-Mellanox.pub | sudo apt-key add -" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
-	echo "deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest/$(DIST_NAME_L)$(DIST_VERSION)/$(ARCH) ./" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
+	echo "# wget -qO - https://linux.mellanox.com/public/repo/doca/latest-2.9-LTS/$(DIST_NAME_L)$(DIST_VERSION)/$(ARCH)/nvidia-doca-debian-gpg-public-key.asc | sudo apt-key add -" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
+	echo "deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest-2.9-LTS/$(DIST_NAME_L)$(DIST_VERSION)/$(ARCH) ./" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	chmod 644 debian/$(pname)/etc/apt/sources.list.d/doca.list
 
 	# UDEV rules

--- a/src/doca.list
+++ b/src/doca.list
@@ -3,5 +3,5 @@
 # For more information, refer to http://linux.mellanox.com
 #
 # To add public key:
-# wget -qO - https://linux.mellanox.com/public/repo/doca/latest/ubuntu20.04/aarch64/GPG-KEY-Mellanox.pub | sudo apt-key add -
-deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest/ubuntu20.04/$(ARCH) ./
+# wget -qO - https://linux.mellanox.com/public/repo/doca/latest-2.9-LTS/ubuntu22.04/arm64-dpu/nvidia-doca-debian-gpg-public-key.asc | sudo apt-key add -
+deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest-2.9-LTS/ubuntu22.04/arm64-dpu ./


### PR DESCRIPTION
## Summary

- Replace deprecated `latest` repo pointer with `latest-2.9-LTS` in `debian/rules` and `src/doca.list`
- Rename `ARCH` from `aarch64` to `arm64-dpu` in `debian/rules`
- Replace deprecated `GPG-KEY-Mellanox.pub` with `nvidia-doca-debian-gpg-public-key.asc`
- Update `src/doca.list` example path from `ubuntu20.04/aarch64` to `ubuntu22.04/arm64-dpu`
- Expand `README.md` entry for `src/doca.list` to clarify it is a static example (the actual installed file is generated dynamically by `debian/rules`)

Closes #80, #81, #82

## Test plan
- [ ] Build the package on Ubuntu 22.04 / 24.04 and verify `/etc/apt/sources.list.d/doca.list` contains the `latest-2.9-LTS` URL with `arm64-dpu` and the new key name
- [ ] Build on Debian and verify the same