### PR TITLE
Update src/doca.list: drop legacy GPG key, update arch

### DIFF
--- a/src/doca.list
+++ b/src/doca.list
@@ -3,5 +3,5 @@
 # For more information, refer to http://linux.mellanox.com
 #
 # To add public key:
-# wget -qO - https://linux.mellanox.com/public/repo/doca/latest/ubuntu20.04/aarch64/GPG-KEY-Mellanox.pub | sudo apt-key add -
-deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest/ubuntu20.04/$(ARCH) ./
+# wget -qO - https://linux.mellanox.com/public/repo/doca/latest/ubuntu22.04/arm64-dpu/nvidia-doca-debian-gpg-public-key.asc | sudo apt-key add -
+deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest/ubuntu22.04/arm64-dpu ./


### PR DESCRIPTION
## Summary

- Replace deprecated `GPG-KEY-Mellanox.pub` with `nvidia-doca-debian-gpg-public-key.asc` in `src/doca.list`
- Update example path from `ubuntu20.04/aarch64` to `ubuntu22.04/arm64-dpu`
- `debian/rules` is already correct on master (arm64-dpu + new key + latest)

## Test plan
- [ ] Verify `src/doca.list` matches what `debian/rules` generates at build time