### PR TITLE
Fix GPG key and arch in DOCA repo config for 3.2-LTS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ BF_KERNEL := $(shell dpkg -L mlnx-ofed-kernel-modules | grep -o [0-9].*bluefield
 BF_VERSION := $(shell dpkg-query --showformat='${Version}' --show mlxbf-bootimages 2> /dev/null | sed -e 's/-/./g')
 
 BFB_VERSION := $(shell cat /etc/mlnx-release 2> /dev/null)
-ARCH := aarch64
+ARCH := arm64-dpu
 
 %:
 	dh $@
@@ -47,7 +47,7 @@ override_dh_auto_install:
 	echo "# For more information, refer to http://linux.mellanox.com" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	echo "#" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	echo "# To add public key:" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
-	echo "# wget -qO - https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/$(DIST_NAME_L)$(DIST_VERSION)/aarch64/GPG-KEY-Mellanox.pub | sudo apt-key add -" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
+	echo "# wget -qO - https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/$(DIST_NAME_L)$(DIST_VERSION)/$(ARCH)/nvidia-doca-debian-gpg-public-key.asc | sudo apt-key add -" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	echo "deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/$(DIST_NAME_L)$(DIST_VERSION)/$(ARCH) ./" >> debian/$(pname)/etc/apt/sources.list.d/doca.list
 	chmod 644 debian/$(pname)/etc/apt/sources.list.d/doca.list
 

--- a/src/doca.list
+++ b/src/doca.list
@@ -3,5 +3,5 @@
 # For more information, refer to http://linux.mellanox.com
 #
 # To add public key:
-# wget -qO - https://linux.mellanox.com/public/repo/doca/latest/ubuntu20.04/aarch64/GPG-KEY-Mellanox.pub | sudo apt-key add -
-deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest/ubuntu20.04/$(ARCH) ./
+# wget -qO - https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/ubuntu22.04/arm64-dpu/nvidia-doca-debian-gpg-public-key.asc | sudo apt-key add -
+deb [trusted=yes] https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/ubuntu22.04/arm64-dpu ./


### PR DESCRIPTION
## Summary

- `debian/rules`: rename `ARCH` from `aarch64` to `arm64-dpu`; update GPG key comment to `nvidia-doca-debian-gpg-public-key.asc` (repo pointer `latest-3.2-LTS` was already correct)
- `src/doca.list`: update example to `latest-3.2-LTS/ubuntu22.04/arm64-dpu` with new key name

## Test plan
- [ ] Build on Ubuntu 22.04 and verify `/etc/apt/sources.list.d/doca.list` contains `latest-3.2-LTS`, `arm64-dpu`, and `nvidia-doca-debian-gpg-public-key.asc`