### PR TITLE
Fix golden image BackgroundCopy regression in master

### DIFF
--- a/src/bf-upgrade.env/bmc
+++ b/src/bf-upgrade.env/bmc
@@ -380,7 +380,14 @@ wait_bmc_task_complete()
 
 wait_no_bmc_tasks()
 {
-	bmc_get_task_id
+	local tid=$1
+
+	if [ ! -z "$tid" ]; then
+		task_id=$tid
+		ilog "Received Task id: $task_id"
+	else
+		bmc_get_task_id
+	fi
 	if [ -z "${task_id}" ]; then
 		ilog "No active BMC task"
 		return 0
@@ -730,7 +737,7 @@ update_dpu_golden_image()
 
 			tid=$(echo $output | jq -r '."@odata.id"')
 			ilog "DPU Golden Image update task id: $tid"
-			wait_bmc_task_complete $tid
+			wait_no_bmc_tasks $tid
 
 		else
 			ilog "DPU Golden Image update is not supported for BMC firmware version $BMC_INSTALLED_VERSION"
@@ -840,7 +847,7 @@ update_nic_firmware_golden_image()
 
 			tid=$(echo $output | jq -r '."@odata.id"')
 			ilog "NIC Firmware Golden Image update task id: $tid"
-			wait_bmc_task_complete $tid
+			wait_no_bmc_tasks $tid
 
 		else
 			ilog "NIC Firmware Golden Image update is not supported for BMC firmware version $BMC_INSTALLED_VERSION"


### PR DESCRIPTION
## Summary

- Updates `wait_no_bmc_tasks()` to accept an optional explicit task ID argument, mirroring the interface of `wait_bmc_task_complete()`
- Replaces `wait_bmc_task_complete $tid` with `wait_no_bmc_tasks $tid` in both `update_dpu_golden_image` and `update_nic_firmware_golden_image`

## Why

`wait_bmc_task_complete` always polls `BackgroundCopyStatus` on `Bluefield_ERoT`, which is irrelevant for golden-image operations and causes an unnecessary ~10 min stall. `wait_no_bmc_tasks` monitors only task state, which is all that is needed here.

Fixes #5087906.