### PR TITLE
bfiso-post-install.sh: Set action for mlx_ipmid service based on device type

### DIFF
--- a/src/iso/bfiso-post-install.sh
+++ b/src/iso/bfiso-post-install.sh
@@ -497,7 +497,7 @@ configure_services()
 	ilog "$(/bin/systemctl enable mlnx_snap.service > /dev/null 2>&1)"
 	ilog "$(/bin/systemctl enable acpid.service > /dev/null 2>&1)"
 	ilog "$(/bin/systemctl enable mlx-openipmi.service > /dev/null 2>&1)"
-	ilog "$(/bin/systemctl enable mlx_ipmid.service > /dev/null 2>&1)"
+	if is_bf4; then ACTION=disable; else ACTION=enable; fi; ilog "$(/bin/systemctl $ACTION mlx_ipmid.service > /dev/null 2>&1)"
 	ilog "$(/bin/systemctl enable set_emu_param.service > /dev/null 2>&1)"
 	ilog "$(/bin/systemctl enable bfvcheck.service > /dev/null 2>&1)"
 	ilog "$(/bin/systemctl enable bfup.service > /dev/null 2>&1)"


### PR DESCRIPTION
Disable mlx_ipmid.service for BF4 devices

RM #5107358